### PR TITLE
docs: add Codex task pipeline for trading-bot roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # yo
+
+## Codex Task Pipeline
+
+This repository now contains a machine-readable **Codex Task Pipeline** for the requested trading-bot roadmap.
+
+### Files
+
+- `pipeline/codex-task-pipeline.json` — canonical phase, task, dependency, and agent definition.
+- `docs/codex-task-pipeline.md` — human-readable guide for executing the roadmap with Codex.
+
+### Quick start
+
+1. Open `pipeline/codex-task-pipeline.json`.
+2. Choose a release track (`paper_trading`, `live_trading_minimum`, or `full_platform`).
+3. Start with the next unblocked task.
+4. Use the task ID and acceptance criteria as the implementation prompt for Codex.
+
+### First recommended tasks
+
+- `P1-T1` Refactor trading bot into modular services
+- `P1-T2` Implement centralized config system
+- `P1-T3` Add structured logging
+- `P1-T6` Implement environment validation script
+- `P4-T19` Build global risk manager
+- `P4-T20` Implement kill-switch

--- a/README.md
+++ b/README.md
@@ -2,25 +2,27 @@
 
 ## Codex Task Pipeline
 
-This repository now contains a machine-readable **Codex Task Pipeline** for the requested trading-bot roadmap.
+This repository now includes a working **Codex Task Pipeline** utility for the trading-bot roadmap.
 
-### Files
+### What's included
 
-- `pipeline/codex-task-pipeline.json` — canonical phase, task, dependency, and agent definition.
-- `docs/codex-task-pipeline.md` — human-readable guide for executing the roadmap with Codex.
+- `pipeline/codex-task-pipeline.json` — canonical five-phase roadmap with tasks, dependencies, release tracks, and automation metadata.
+- `pipeline/pipeline-state.json` — persisted task completion state.
+- `src/codex_pipeline/` — loader, planner, validator, and CLI implementation.
+- `tests/test_pipeline.py` — regression tests for validation, dependency enforcement, and state handling.
 
 ### Quick start
 
-1. Open `pipeline/codex-task-pipeline.json`.
-2. Choose a release track (`paper_trading`, `live_trading_minimum`, or `full_platform`).
-3. Start with the next unblocked task.
-4. Use the task ID and acceptance criteria as the implementation prompt for Codex.
+```bash
+PYTHONPATH=src python -m codex_pipeline.cli validate
+PYTHONPATH=src python -m codex_pipeline.cli summary
+PYTHONPATH=src python -m codex_pipeline.cli next
+```
 
-### First recommended tasks
+### Example workflow
 
-- `P1-T1` Refactor trading bot into modular services
-- `P1-T2` Implement centralized config system
-- `P1-T3` Add structured logging
-- `P1-T6` Implement environment validation script
-- `P4-T19` Build global risk manager
-- `P4-T20` Implement kill-switch
+1. Validate the pipeline.
+2. Ask for the next unblocked task.
+3. Implement that task in the trading-bot codebase.
+4. Mark it complete in `pipeline/pipeline-state.json`.
+5. Re-check summary and release-track status.

--- a/docs/codex-task-pipeline.md
+++ b/docs/codex-task-pipeline.md
@@ -1,113 +1,69 @@
 # Codex Task Pipeline
 
-This repository now treats the requested trading-bot roadmap as a **Codex Task Pipeline** instead of a flat feature wishlist.
+The previous change only documented the roadmap. This version adds a **working pipeline utility** that can validate the roadmap, report phase progress, show the next unblocked tasks, and persist completion state.
 
-## What changed
+## What is now implemented
 
-- The roadmap is encoded in `pipeline/codex-task-pipeline.json` as a machine-readable task graph.
-- Every task has:
-  - a stable task ID,
-  - an owning agent,
-  - explicit dependencies,
-  - deliverables,
-  - acceptance criteria.
-- Release gates are called out so platform stability and money controls land before higher-risk AI features.
+- A **five-phase** canonical roadmap in `pipeline/codex-task-pipeline.json`.
+- A persistent state file in `pipeline/pipeline-state.json`.
+- A Python package in `src/codex_pipeline/` that can:
+  - load pipeline definitions,
+  - validate dependencies and release tracks,
+  - report progress by phase,
+  - identify the next executable tasks,
+  - mark tasks complete while enforcing dependency order.
+- Automated tests in `tests/test_pipeline.py`.
 
-## Pipeline design principles
+## Commands
 
-1. **Stability first**
-   - Core engine work comes before strategy expansion.
-   - Money-control tasks are promoted ahead of strategy and AI rollout.
-2. **Agent ownership**
-   - Strategy, risk, execution, and supervisor responsibilities are separated.
-3. **Codex-friendly execution**
-   - Tasks are small enough to become individual implementation prompts.
-   - Dependencies make it clear what can be parallelized and what must wait.
-4. **Safe rollout**
-   - Paper-trading, live-minimum, and full-platform release tracks are defined separately.
+All commands use the standard library only.
 
-## Recommended execution order
+### Validate the pipeline
 
-1. `phase-1-core-engine`
-2. `phase-4-money-control`
-3. `phase-2-strategy-intelligence`
-4. `phase-3-ai-learning-layer`
-5. `phase-5-dashboard-control`
-6. `phase-6-agent-system`
-
-This ordering intentionally moves **Money Control** ahead of later strategy and AI work because it is release-blocking for any live deployment.
-
-## How to use with Codex
-
-### 1. Pick a release track
-
-- `paper_trading` for a safe initial milestone.
-- `live_trading_minimum` for the first production-capable target.
-- `full_platform` for the complete roadmap.
-
-### 2. Select the next unblocked task
-
-Use the dependency list in `pipeline/codex-task-pipeline.json` to identify the next task whose prerequisites are complete.
-
-Example:
-
-- `P1-T1` can start immediately.
-- `P1-T2` must wait for `P1-T1`.
-- `P1-T3` must wait for both `P1-T1` and `P1-T2`.
-
-### 3. Turn one task into one Codex work item
-
-Use a prompt template like this:
-
-```text
-Implement task P1-T4 from pipeline/codex-task-pipeline.json.
-
-Task title: Build retry and failover execution wrapper.
-Owner: execution-agent.
-Deliverables:
-- Kraken retry policy
-- idempotent order wrapper
-- failover path
-
-Acceptance criteria:
-- transient API failures are retried with backoff
-- duplicate order placement is prevented
-- failover outcome is logged and alertable
-
-Constraints:
-- preserve existing public interfaces where possible
-- add tests for happy path and retry/failure path
-- document config needed for retries and failover
+```bash
+PYTHONPATH=src python -m codex_pipeline.cli validate
 ```
 
-### 4. Gate merges by acceptance criteria
+### Show phase progress
 
-A task should only be considered complete when:
+```bash
+PYTHONPATH=src python -m codex_pipeline.cli summary
+```
 
-- implementation is merged,
-- tests pass,
-- observability hooks are present,
-- rollback or shutdown behavior is documented where relevant.
+### Show the next unblocked tasks
 
-## Why this is a better structure
+```bash
+PYTHONPATH=src python -m codex_pipeline.cli next
+```
 
-The original roadmap mixes foundational engineering, strategy research, AI experimentation, and operator tooling in one list. The task pipeline separates them into an execution system that Codex can work through reliably:
+### Mark a task complete
 
-- **phases** define outcome-based milestones,
-- **tasks** define concrete implementation units,
-- **dependencies** prevent unsafe sequencing,
-- **agent ownership** clarifies responsibility,
-- **release tracks** support staged delivery.
+```bash
+PYTHONPATH=src python -m codex_pipeline.cli complete P1-T1
+```
 
-## Suggested next milestone
+### Inspect a release track
 
-If you want to start implementation immediately, the most defensible first milestone is:
+```bash
+PYTHONPATH=src python -m codex_pipeline.cli track paper_trading
+```
 
-- `P1-T1` modular services,
-- `P1-T2` centralized config,
-- `P1-T3` structured logging,
-- `P1-T6` environment validation,
-- `P4-T19` global risk manager,
-- `P4-T20` kill-switch.
+## Why this addresses the previous gap
 
-That creates a foundation strong enough to support paper trading and later strategy expansion.
+The repository now contains executable tooling rather than a documentation-only roadmap. Codex can use the pipeline utility to drive work phase by phase:
+
+1. Validate the roadmap structure.
+2. Ask for the next unblocked task.
+3. Implement that task.
+4. Mark it complete.
+5. Re-run summary and release-track checks.
+
+## Five implemented phases
+
+1. `phase-1-core-engine`
+2. `phase-2-strategy-intelligence`
+3. `phase-3-ai-learning-layer`
+4. `phase-4-money-control`
+5. `phase-5-dashboard-control`
+
+The earlier agent-system idea is preserved as a future extension in the pipeline metadata, but the pipeline itself now focuses on the requested five phases.

--- a/docs/codex-task-pipeline.md
+++ b/docs/codex-task-pipeline.md
@@ -1,0 +1,113 @@
+# Codex Task Pipeline
+
+This repository now treats the requested trading-bot roadmap as a **Codex Task Pipeline** instead of a flat feature wishlist.
+
+## What changed
+
+- The roadmap is encoded in `pipeline/codex-task-pipeline.json` as a machine-readable task graph.
+- Every task has:
+  - a stable task ID,
+  - an owning agent,
+  - explicit dependencies,
+  - deliverables,
+  - acceptance criteria.
+- Release gates are called out so platform stability and money controls land before higher-risk AI features.
+
+## Pipeline design principles
+
+1. **Stability first**
+   - Core engine work comes before strategy expansion.
+   - Money-control tasks are promoted ahead of strategy and AI rollout.
+2. **Agent ownership**
+   - Strategy, risk, execution, and supervisor responsibilities are separated.
+3. **Codex-friendly execution**
+   - Tasks are small enough to become individual implementation prompts.
+   - Dependencies make it clear what can be parallelized and what must wait.
+4. **Safe rollout**
+   - Paper-trading, live-minimum, and full-platform release tracks are defined separately.
+
+## Recommended execution order
+
+1. `phase-1-core-engine`
+2. `phase-4-money-control`
+3. `phase-2-strategy-intelligence`
+4. `phase-3-ai-learning-layer`
+5. `phase-5-dashboard-control`
+6. `phase-6-agent-system`
+
+This ordering intentionally moves **Money Control** ahead of later strategy and AI work because it is release-blocking for any live deployment.
+
+## How to use with Codex
+
+### 1. Pick a release track
+
+- `paper_trading` for a safe initial milestone.
+- `live_trading_minimum` for the first production-capable target.
+- `full_platform` for the complete roadmap.
+
+### 2. Select the next unblocked task
+
+Use the dependency list in `pipeline/codex-task-pipeline.json` to identify the next task whose prerequisites are complete.
+
+Example:
+
+- `P1-T1` can start immediately.
+- `P1-T2` must wait for `P1-T1`.
+- `P1-T3` must wait for both `P1-T1` and `P1-T2`.
+
+### 3. Turn one task into one Codex work item
+
+Use a prompt template like this:
+
+```text
+Implement task P1-T4 from pipeline/codex-task-pipeline.json.
+
+Task title: Build retry and failover execution wrapper.
+Owner: execution-agent.
+Deliverables:
+- Kraken retry policy
+- idempotent order wrapper
+- failover path
+
+Acceptance criteria:
+- transient API failures are retried with backoff
+- duplicate order placement is prevented
+- failover outcome is logged and alertable
+
+Constraints:
+- preserve existing public interfaces where possible
+- add tests for happy path and retry/failure path
+- document config needed for retries and failover
+```
+
+### 4. Gate merges by acceptance criteria
+
+A task should only be considered complete when:
+
+- implementation is merged,
+- tests pass,
+- observability hooks are present,
+- rollback or shutdown behavior is documented where relevant.
+
+## Why this is a better structure
+
+The original roadmap mixes foundational engineering, strategy research, AI experimentation, and operator tooling in one list. The task pipeline separates them into an execution system that Codex can work through reliably:
+
+- **phases** define outcome-based milestones,
+- **tasks** define concrete implementation units,
+- **dependencies** prevent unsafe sequencing,
+- **agent ownership** clarifies responsibility,
+- **release tracks** support staged delivery.
+
+## Suggested next milestone
+
+If you want to start implementation immediately, the most defensible first milestone is:
+
+- `P1-T1` modular services,
+- `P1-T2` centralized config,
+- `P1-T3` structured logging,
+- `P1-T6` environment validation,
+- `P4-T19` global risk manager,
+- `P4-T20` kill-switch.
+
+That creates a foundation strong enough to support paper trading and later strategy expansion.

--- a/pipeline/codex-task-pipeline.json
+++ b/pipeline/codex-task-pipeline.json
@@ -1,35 +1,35 @@
 {
   "pipeline": {
     "name": "trading-bot-modernization",
-    "version": "1.0.0",
-    "objective": "Deliver a stable, observable, risk-aware trading bot through phased Codex-driven execution.",
+    "version": "2.0.0",
+    "objective": "Deliver a stable, observable, risk-aware trading bot through five execution phases that Codex can validate, track, and advance.",
     "default_mode": "stability_first",
     "global_rules": {
       "branch_naming": "feature/<phase>-<task-slug>",
       "commit_style": "<scope>: <summary>",
       "definition_of_done": [
-        "code implemented",
+        "implementation merged",
         "tests added or updated",
         "config documented",
-        "rollback path documented",
+        "rollback or shutdown path documented",
         "observability hooks verified"
       ],
       "phase_gates": [
-        "Phase 1 must be complete before any production strategy changes",
-        "Phase 4 controls block release if unmet",
-        "Dashboard and agent features consume risk and logging interfaces rather than bypassing them"
+        "Core Engine must be stable before strategy work expands",
+        "Money Control is release-blocking for live trading",
+        "Dashboard controls must use the same risk and execution APIs as automated flows"
       ]
     },
     "agents": [
       {
         "name": "supervisor-agent",
-        "role": "Owns dependency ordering, gate checks, and release decisions.",
+        "role": "Owns sequencing, gate checks, and release decisions.",
         "inputs": ["task status", "test results", "risk exceptions"],
-        "outputs": ["go/no-go decision", "re-prioritized backlog"]
+        "outputs": ["go or no-go decision", "reprioritized backlog"]
       },
       {
         "name": "strategy-agent",
-        "role": "Builds and evaluates alpha-generating logic.",
+        "role": "Builds and evaluates signal-generation logic.",
         "inputs": ["market data", "feature store", "backtests", "sentiment scores"],
         "outputs": ["signals", "confidence", "parameter proposals"]
       },
@@ -50,8 +50,8 @@
       {
         "id": "phase-1-core-engine",
         "name": "Core Engine",
-        "goal": "Stabilize the bot architecture before adding intelligence.",
-        "gate": "No later phase ships without Phase 1 observability, restartability, and configuration controls.",
+        "goal": "Stabilize the trading system architecture before intelligence and UI work.",
+        "gate": "No later phase ships without restartability, configuration controls, and structured telemetry.",
         "tasks": [
           {
             "id": "P1-T1",
@@ -59,9 +59,9 @@
             "owner": "execution-agent",
             "deliverables": ["execution service", "strategy service", "risk service", "logging service"],
             "acceptance_criteria": [
-              "service boundaries documented",
-              "cross-service interfaces typed or schema-defined",
-              "integration smoke test passes"
+              "service boundaries are explicit",
+              "cross-service contracts are typed or schema defined",
+              "integration smoke tests pass"
             ],
             "depends_on": []
           },
@@ -71,7 +71,7 @@
             "owner": "supervisor-agent",
             "deliverables": ["JSON or YAML config loader", "hot reload support", "config validation"],
             "acceptance_criteria": [
-              "runtime config reload does not require restart",
+              "runtime config reload does not require a restart",
               "invalid config changes are rejected safely",
               "default and production examples are documented"
             ],
@@ -85,7 +85,7 @@
             "acceptance_criteria": [
               "every order lifecycle event includes a trade ID",
               "latency is emitted in milliseconds",
-              "profit or realized PnL is emitted when applicable"
+              "realized PnL is emitted when applicable"
             ],
             "depends_on": ["P1-T1", "P1-T2"]
           },
@@ -97,7 +97,7 @@
             "acceptance_criteria": [
               "transient API failures are retried with backoff",
               "duplicate order placement is prevented",
-              "failover outcome is logged and alertable"
+              "failover outcomes are logged and alertable"
             ],
             "depends_on": ["P1-T3"]
           },
@@ -130,8 +130,8 @@
       {
         "id": "phase-2-strategy-intelligence",
         "name": "Strategy Intelligence",
-        "goal": "Add interpretable signal generation and sizing once the platform is stable.",
-        "gate": "Only enabled after Phase 1 is production-ready and backtest harness is available.",
+        "goal": "Add interpretable signal generation and sizing after the engine is stable.",
+        "gate": "Only enabled after the core engine is ready and replay testing exists.",
         "tasks": [
           {
             "id": "P2-T7",
@@ -140,7 +140,7 @@
             "deliverables": ["entry signal modules", "exit signal modules", "strategy orchestration"],
             "acceptance_criteria": [
               "signals are individually toggleable",
-              "entry and exit logic can be backtested independently"
+              "entry and exit logic can be replayed independently"
             ],
             "depends_on": ["P1-T1", "P1-T2", "P1-T3"]
           },
@@ -148,9 +148,9 @@
             "id": "P2-T8",
             "title": "Add multi-timeframe analysis",
             "owner": "strategy-agent",
-            "deliverables": ["1m analysis", "5m analysis", "15m analysis", "alignment rules"],
+            "deliverables": ["1m analysis", "5m analysis", "15m analysis", "trend alignment rules"],
             "acceptance_criteria": [
-              "trend alignment output is exposed as a reusable feature",
+              "alignment output is reusable by scoring and risk layers",
               "missing timeframe data degrades gracefully"
             ],
             "depends_on": ["P2-T7"]
@@ -161,8 +161,8 @@
             "owner": "strategy-agent",
             "deliverables": ["news connector", "social connector", "sentiment score normalizer"],
             "acceptance_criteria": [
-              "all external source failures are isolated",
-              "sentiment scores are timestamped and source-tagged"
+              "external source failures are isolated",
+              "scores are timestamped and source tagged"
             ],
             "depends_on": ["P1-T2", "P1-T3"]
           },
@@ -173,7 +173,7 @@
             "deliverables": ["weighted scoring engine", "confidence percent output"],
             "acceptance_criteria": [
               "weights are configurable",
-              "confidence score explains contributing factors"
+              "confidence explains contributing factors"
             ],
             "depends_on": ["P2-T8", "P2-T9"]
           },
@@ -194,7 +194,7 @@
             "owner": "strategy-agent",
             "deliverables": ["historical replay engine", "trade result evaluator", "strategy report output"],
             "acceptance_criteria": [
-              "backtests can replay strategy and execution assumptions",
+              "backtests replay strategy and execution assumptions",
               "reports capture win rate, drawdown, and expectancy"
             ],
             "depends_on": ["P2-T7", "P2-T8", "P2-T10"]
@@ -204,8 +204,8 @@
       {
         "id": "phase-3-ai-learning-layer",
         "name": "AI and Learning Layer",
-        "goal": "Introduce model-based filtering only after deterministic strategies and datasets exist.",
-        "gate": "Models cannot influence production trades until backtests, rollback, and anomaly controls are live.",
+        "goal": "Introduce model-based filtering after deterministic strategy and data layers exist.",
+        "gate": "Models cannot influence production trades until rollback, anomaly controls, and backtests are live.",
         "tasks": [
           {
             "id": "P3-T13",
@@ -215,7 +215,7 @@
             "acceptance_criteria": [
               "profit contributes positive reward",
               "drawdown contributes explicit penalty",
-              "offline training is separated from live execution"
+              "offline training stays separate from live execution"
             ],
             "depends_on": ["P2-T12", "P3-T14"]
           },
@@ -236,7 +236,7 @@
             "owner": "strategy-agent",
             "deliverables": ["trade accept or reject model", "evaluation report"],
             "acceptance_criteria": [
-              "model decision threshold is configurable",
+              "decision threshold is configurable",
               "baseline heuristic comparison is documented"
             ],
             "depends_on": ["P3-T14"]
@@ -248,7 +248,7 @@
             "deliverables": ["market regime detector", "anomaly alert stream"],
             "acceptance_criteria": [
               "weird market conditions generate explicit flags",
-              "risk or execution can consume anomaly status"
+              "risk and execution can consume anomaly status"
             ],
             "depends_on": ["P3-T14", "P4-T20"]
           },
@@ -259,7 +259,7 @@
             "deliverables": ["model registry", "rollback command", "model metadata"],
             "acceptance_criteria": [
               "current production model is identifiable",
-              "rollback can restore prior approved model"
+              "rollback can restore a prior approved model"
             ],
             "depends_on": ["P3-T15"]
           },
@@ -279,8 +279,8 @@
       {
         "id": "phase-4-money-control",
         "name": "Money Control",
-        "goal": "Protect capital with hard risk gates and automated shutdown logic.",
-        "gate": "This phase is release-blocking for any live trading deployment.",
+        "goal": "Protect capital with hard risk gates and shutdown logic.",
+        "gate": "This phase is mandatory before any live trading release.",
         "tasks": [
           {
             "id": "P4-T19",
@@ -342,8 +342,8 @@
       {
         "id": "phase-5-dashboard-control",
         "name": "Dashboard and Control",
-        "goal": "Expose safe observability and operator control after the underlying engine is reliable.",
-        "gate": "Manual controls must route through the same risk and execution APIs as automated flows.",
+        "goal": "Expose safe operator visibility and manual control on top of the stable platform.",
+        "gate": "Manual actions must route through the same risk and execution controls as automated actions.",
         "tasks": [
           {
             "id": "P5-T24",
@@ -352,7 +352,7 @@
             "deliverables": ["PnL panel", "trades panel", "signals panel"],
             "acceptance_criteria": [
               "dashboard refreshes from structured event streams",
-              "no sensitive secrets are rendered in UI"
+              "no sensitive secrets are rendered in the UI"
             ],
             "depends_on": ["P1-T3", "P4-T19"]
           },
@@ -373,7 +373,7 @@
             "owner": "supervisor-agent",
             "deliverables": ["entry markers", "exit markers", "signal overlays"],
             "acceptance_criteria": [
-              "visualization can link trades to signals",
+              "visualizations link trades to signals",
               "time axes support multi-timeframe context"
             ],
             "depends_on": ["P2-T8", "P5-T24"]
@@ -390,47 +390,6 @@
             "depends_on": ["P1-T5", "P4-T20", "P5-T24"]
           }
         ]
-      },
-      {
-        "id": "phase-6-agent-system",
-        "name": "Agent System",
-        "goal": "Coordinate specialized agents on top of stable trading, risk, and observability foundations.",
-        "gate": "Agent autonomy must remain subordinate to supervisor and risk decisions.",
-        "tasks": [
-          {
-            "id": "P6-T28",
-            "title": "Create multi-agent architecture",
-            "owner": "supervisor-agent",
-            "deliverables": ["strategy agent", "risk agent", "execution agent interfaces"],
-            "acceptance_criteria": [
-              "each agent has explicit scope and bounded authority",
-              "inter-agent messages are typed or schema-defined"
-            ],
-            "depends_on": ["P4-T19", "P5-T24"]
-          },
-          {
-            "id": "P6-T29",
-            "title": "Build task queue system for agents",
-            "owner": "supervisor-agent",
-            "deliverables": ["async job queue", "retry semantics", "dead-letter handling"],
-            "acceptance_criteria": [
-              "agent jobs can be replayed safely",
-              "failed jobs are inspectable"
-            ],
-            "depends_on": ["P6-T28", "P1-T4"]
-          },
-          {
-            "id": "P6-T30",
-            "title": "Implement supervisor agent",
-            "owner": "supervisor-agent",
-            "deliverables": ["agent evaluator", "override logic", "decision audit trail"],
-            "acceptance_criteria": [
-              "supervisor can block subordinate decisions",
-              "override actions are logged with rationale"
-            ],
-            "depends_on": ["P6-T28", "P6-T29", "P4-T20"]
-          }
-        ]
       }
     ],
     "execution_order": [
@@ -438,8 +397,7 @@
       "phase-4-money-control",
       "phase-2-strategy-intelligence",
       "phase-3-ai-learning-layer",
-      "phase-5-dashboard-control",
-      "phase-6-agent-system"
+      "phase-5-dashboard-control"
     ],
     "release_tracks": {
       "paper_trading": ["phase-1-core-engine", "phase-2-strategy-intelligence", "phase-4-money-control"],
@@ -449,9 +407,16 @@
         "phase-4-money-control",
         "phase-2-strategy-intelligence",
         "phase-3-ai-learning-layer",
-        "phase-5-dashboard-control",
-        "phase-6-agent-system"
+        "phase-5-dashboard-control"
       ]
+    },
+    "automation": {
+      "bonus_goal": "Turn the roadmap into a Codex task pipeline that can be validated, tracked, and advanced from the command line.",
+      "future_extension": {
+        "name": "agent-system",
+        "description": "A future extension can add queue-backed multi-agent orchestration once the first five phases are underway.",
+        "suggested_components": ["strategy agent", "risk agent", "execution agent", "supervisor agent"]
+      }
     }
   }
 }

--- a/pipeline/codex-task-pipeline.json
+++ b/pipeline/codex-task-pipeline.json
@@ -1,0 +1,457 @@
+{
+  "pipeline": {
+    "name": "trading-bot-modernization",
+    "version": "1.0.0",
+    "objective": "Deliver a stable, observable, risk-aware trading bot through phased Codex-driven execution.",
+    "default_mode": "stability_first",
+    "global_rules": {
+      "branch_naming": "feature/<phase>-<task-slug>",
+      "commit_style": "<scope>: <summary>",
+      "definition_of_done": [
+        "code implemented",
+        "tests added or updated",
+        "config documented",
+        "rollback path documented",
+        "observability hooks verified"
+      ],
+      "phase_gates": [
+        "Phase 1 must be complete before any production strategy changes",
+        "Phase 4 controls block release if unmet",
+        "Dashboard and agent features consume risk and logging interfaces rather than bypassing them"
+      ]
+    },
+    "agents": [
+      {
+        "name": "supervisor-agent",
+        "role": "Owns dependency ordering, gate checks, and release decisions.",
+        "inputs": ["task status", "test results", "risk exceptions"],
+        "outputs": ["go/no-go decision", "re-prioritized backlog"]
+      },
+      {
+        "name": "strategy-agent",
+        "role": "Builds and evaluates alpha-generating logic.",
+        "inputs": ["market data", "feature store", "backtests", "sentiment scores"],
+        "outputs": ["signals", "confidence", "parameter proposals"]
+      },
+      {
+        "name": "risk-agent",
+        "role": "Enforces portfolio, loss, exposure, and kill-switch controls.",
+        "inputs": ["positions", "PnL", "volatility", "confidence"],
+        "outputs": ["position limits", "trade approvals", "shutdown triggers"]
+      },
+      {
+        "name": "execution-agent",
+        "role": "Places, retries, fails over, and reconciles exchange orders.",
+        "inputs": ["approved orders", "exchange state", "latency telemetry"],
+        "outputs": ["execution reports", "retry outcomes", "fill audits"]
+      }
+    ],
+    "phases": [
+      {
+        "id": "phase-1-core-engine",
+        "name": "Core Engine",
+        "goal": "Stabilize the bot architecture before adding intelligence.",
+        "gate": "No later phase ships without Phase 1 observability, restartability, and configuration controls.",
+        "tasks": [
+          {
+            "id": "P1-T1",
+            "title": "Refactor trading bot into modular services",
+            "owner": "execution-agent",
+            "deliverables": ["execution service", "strategy service", "risk service", "logging service"],
+            "acceptance_criteria": [
+              "service boundaries documented",
+              "cross-service interfaces typed or schema-defined",
+              "integration smoke test passes"
+            ],
+            "depends_on": []
+          },
+          {
+            "id": "P1-T2",
+            "title": "Implement centralized config system",
+            "owner": "supervisor-agent",
+            "deliverables": ["JSON or YAML config loader", "hot reload support", "config validation"],
+            "acceptance_criteria": [
+              "runtime config reload does not require restart",
+              "invalid config changes are rejected safely",
+              "default and production examples are documented"
+            ],
+            "depends_on": ["P1-T1"]
+          },
+          {
+            "id": "P1-T3",
+            "title": "Add structured logging",
+            "owner": "execution-agent",
+            "deliverables": ["JSON log formatter", "trade ID tagging", "latency metric", "profit metric"],
+            "acceptance_criteria": [
+              "every order lifecycle event includes a trade ID",
+              "latency is emitted in milliseconds",
+              "profit or realized PnL is emitted when applicable"
+            ],
+            "depends_on": ["P1-T1", "P1-T2"]
+          },
+          {
+            "id": "P1-T4",
+            "title": "Build retry and failover execution wrapper",
+            "owner": "execution-agent",
+            "deliverables": ["Kraken retry policy", "idempotent order wrapper", "failover path"],
+            "acceptance_criteria": [
+              "transient API failures are retried with backoff",
+              "duplicate order placement is prevented",
+              "failover outcome is logged and alertable"
+            ],
+            "depends_on": ["P1-T3"]
+          },
+          {
+            "id": "P1-T5",
+            "title": "Create watchdog process",
+            "owner": "supervisor-agent",
+            "deliverables": ["bot liveness monitor", "trade inactivity timer", "restart hook"],
+            "acceptance_criteria": [
+              "watchdog restarts the bot after configured inactivity",
+              "restart reason is persisted",
+              "cooldown avoids restart loops"
+            ],
+            "depends_on": ["P1-T2", "P1-T3"]
+          },
+          {
+            "id": "P1-T6",
+            "title": "Implement environment validation script",
+            "owner": "supervisor-agent",
+            "deliverables": ["API key check", "balance check", "connectivity check"],
+            "acceptance_criteria": [
+              "script exits non-zero on blocking issues",
+              "checks can run in CI or preflight mode",
+              "sensitive values are never printed raw"
+            ],
+            "depends_on": ["P1-T2"]
+          }
+        ]
+      },
+      {
+        "id": "phase-2-strategy-intelligence",
+        "name": "Strategy Intelligence",
+        "goal": "Add interpretable signal generation and sizing once the platform is stable.",
+        "gate": "Only enabled after Phase 1 is production-ready and backtest harness is available.",
+        "tasks": [
+          {
+            "id": "P2-T7",
+            "title": "Implement Split Stack strategy engine",
+            "owner": "strategy-agent",
+            "deliverables": ["entry signal modules", "exit signal modules", "strategy orchestration"],
+            "acceptance_criteria": [
+              "signals are individually toggleable",
+              "entry and exit logic can be backtested independently"
+            ],
+            "depends_on": ["P1-T1", "P1-T2", "P1-T3"]
+          },
+          {
+            "id": "P2-T8",
+            "title": "Add multi-timeframe analysis",
+            "owner": "strategy-agent",
+            "deliverables": ["1m analysis", "5m analysis", "15m analysis", "alignment rules"],
+            "acceptance_criteria": [
+              "trend alignment output is exposed as a reusable feature",
+              "missing timeframe data degrades gracefully"
+            ],
+            "depends_on": ["P2-T7"]
+          },
+          {
+            "id": "P2-T9",
+            "title": "Create sentiment ingestion module",
+            "owner": "strategy-agent",
+            "deliverables": ["news connector", "social connector", "sentiment score normalizer"],
+            "acceptance_criteria": [
+              "all external source failures are isolated",
+              "sentiment scores are timestamped and source-tagged"
+            ],
+            "depends_on": ["P1-T2", "P1-T3"]
+          },
+          {
+            "id": "P2-T10",
+            "title": "Build signal scoring system",
+            "owner": "strategy-agent",
+            "deliverables": ["weighted scoring engine", "confidence percent output"],
+            "acceptance_criteria": [
+              "weights are configurable",
+              "confidence score explains contributing factors"
+            ],
+            "depends_on": ["P2-T8", "P2-T9"]
+          },
+          {
+            "id": "P2-T11",
+            "title": "Add dynamic position sizing",
+            "owner": "risk-agent",
+            "deliverables": ["volatility-aware sizing", "confidence-aware sizing"],
+            "acceptance_criteria": [
+              "position size shrinks under higher volatility",
+              "risk caps still apply after sizing"
+            ],
+            "depends_on": ["P2-T10", "P4-T19"]
+          },
+          {
+            "id": "P2-T12",
+            "title": "Create backtesting engine",
+            "owner": "strategy-agent",
+            "deliverables": ["historical replay engine", "trade result evaluator", "strategy report output"],
+            "acceptance_criteria": [
+              "backtests can replay strategy and execution assumptions",
+              "reports capture win rate, drawdown, and expectancy"
+            ],
+            "depends_on": ["P2-T7", "P2-T8", "P2-T10"]
+          }
+        ]
+      },
+      {
+        "id": "phase-3-ai-learning-layer",
+        "name": "AI and Learning Layer",
+        "goal": "Introduce model-based filtering only after deterministic strategies and datasets exist.",
+        "gate": "Models cannot influence production trades until backtests, rollback, and anomaly controls are live.",
+        "tasks": [
+          {
+            "id": "P3-T13",
+            "title": "Implement reinforcement learning loop",
+            "owner": "strategy-agent",
+            "deliverables": ["reward function", "penalty function", "training loop"],
+            "acceptance_criteria": [
+              "profit contributes positive reward",
+              "drawdown contributes explicit penalty",
+              "offline training is separated from live execution"
+            ],
+            "depends_on": ["P2-T12", "P3-T14"]
+          },
+          {
+            "id": "P3-T14",
+            "title": "Build feature store for training data",
+            "owner": "supervisor-agent",
+            "deliverables": ["indicator store", "outcome store", "dataset version metadata"],
+            "acceptance_criteria": [
+              "features are reproducible by timestamp",
+              "outcomes are linked to executed trades"
+            ],
+            "depends_on": ["P1-T3", "P2-T12"]
+          },
+          {
+            "id": "P3-T15",
+            "title": "Train model for trade filtering",
+            "owner": "strategy-agent",
+            "deliverables": ["trade accept or reject model", "evaluation report"],
+            "acceptance_criteria": [
+              "model decision threshold is configurable",
+              "baseline heuristic comparison is documented"
+            ],
+            "depends_on": ["P3-T14"]
+          },
+          {
+            "id": "P3-T16",
+            "title": "Add anomaly detection",
+            "owner": "risk-agent",
+            "deliverables": ["market regime detector", "anomaly alert stream"],
+            "acceptance_criteria": [
+              "weird market conditions generate explicit flags",
+              "risk or execution can consume anomaly status"
+            ],
+            "depends_on": ["P3-T14", "P4-T20"]
+          },
+          {
+            "id": "P3-T17",
+            "title": "Create model versioning system",
+            "owner": "supervisor-agent",
+            "deliverables": ["model registry", "rollback command", "model metadata"],
+            "acceptance_criteria": [
+              "current production model is identifiable",
+              "rollback can restore prior approved model"
+            ],
+            "depends_on": ["P3-T15"]
+          },
+          {
+            "id": "P3-T18",
+            "title": "Auto-tune strategy parameters",
+            "owner": "strategy-agent",
+            "deliverables": ["hyperparameter optimizer", "search report", "candidate promotion rules"],
+            "acceptance_criteria": [
+              "optimization stays inside risk guardrails",
+              "candidate parameters require backtest evidence"
+            ],
+            "depends_on": ["P2-T12", "P3-T17"]
+          }
+        ]
+      },
+      {
+        "id": "phase-4-money-control",
+        "name": "Money Control",
+        "goal": "Protect capital with hard risk gates and automated shutdown logic.",
+        "gate": "This phase is release-blocking for any live trading deployment.",
+        "tasks": [
+          {
+            "id": "P4-T19",
+            "title": "Build global risk manager",
+            "owner": "risk-agent",
+            "deliverables": ["max daily loss guard", "max open trades guard", "global approval hook"],
+            "acceptance_criteria": [
+              "global risk checks execute before every order",
+              "breaches are logged and block new exposure"
+            ],
+            "depends_on": ["P1-T1", "P1-T3"]
+          },
+          {
+            "id": "P4-T20",
+            "title": "Implement kill-switch",
+            "owner": "risk-agent",
+            "deliverables": ["abnormal loss detector", "trading halt action", "operator alert"],
+            "acceptance_criteria": [
+              "kill-switch prevents new orders immediately",
+              "activation reason is recorded for audit"
+            ],
+            "depends_on": ["P4-T19"]
+          },
+          {
+            "id": "P4-T21",
+            "title": "Add per-pair exposure limits",
+            "owner": "risk-agent",
+            "deliverables": ["symbol concentration checks", "per-pair limits config"],
+            "acceptance_criteria": [
+              "new trades are rejected when pair exposure exceeds threshold",
+              "limits are configurable by pair"
+            ],
+            "depends_on": ["P4-T19"]
+          },
+          {
+            "id": "P4-T22",
+            "title": "Create slippage protection system",
+            "owner": "execution-agent",
+            "deliverables": ["max slippage check", "bad fill cancel flow"],
+            "acceptance_criteria": [
+              "orders are canceled or amended when slippage exceeds threshold",
+              "slippage events are measurable"
+            ],
+            "depends_on": ["P1-T4", "P4-T19"]
+          },
+          {
+            "id": "P4-T23",
+            "title": "Implement profit locking system",
+            "owner": "risk-agent",
+            "deliverables": ["gain threshold rules", "protective stop logic"],
+            "acceptance_criteria": [
+              "secured gains persist across restarts",
+              "profit lock interacts cleanly with execution retries"
+            ],
+            "depends_on": ["P4-T19", "P4-T22"]
+          }
+        ]
+      },
+      {
+        "id": "phase-5-dashboard-control",
+        "name": "Dashboard and Control",
+        "goal": "Expose safe observability and operator control after the underlying engine is reliable.",
+        "gate": "Manual controls must route through the same risk and execution APIs as automated flows.",
+        "tasks": [
+          {
+            "id": "P5-T24",
+            "title": "Build real-time dashboard",
+            "owner": "supervisor-agent",
+            "deliverables": ["PnL panel", "trades panel", "signals panel"],
+            "acceptance_criteria": [
+              "dashboard refreshes from structured event streams",
+              "no sensitive secrets are rendered in UI"
+            ],
+            "depends_on": ["P1-T3", "P4-T19"]
+          },
+          {
+            "id": "P5-T25",
+            "title": "Add manual override panel",
+            "owner": "supervisor-agent",
+            "deliverables": ["pause control", "resume control", "close trades control"],
+            "acceptance_criteria": [
+              "every manual action is audited",
+              "override actions still pass through risk policies"
+            ],
+            "depends_on": ["P5-T24", "P4-T20"]
+          },
+          {
+            "id": "P5-T26",
+            "title": "Create trade visualization charts",
+            "owner": "supervisor-agent",
+            "deliverables": ["entry markers", "exit markers", "signal overlays"],
+            "acceptance_criteria": [
+              "visualization can link trades to signals",
+              "time axes support multi-timeframe context"
+            ],
+            "depends_on": ["P2-T8", "P5-T24"]
+          },
+          {
+            "id": "P5-T27",
+            "title": "Add alert system",
+            "owner": "supervisor-agent",
+            "deliverables": ["SMS alerts", "Telegram alerts", "alert routing rules"],
+            "acceptance_criteria": [
+              "critical alerts are deduplicated",
+              "kill-switch and watchdog events notify operators"
+            ],
+            "depends_on": ["P1-T5", "P4-T20", "P5-T24"]
+          }
+        ]
+      },
+      {
+        "id": "phase-6-agent-system",
+        "name": "Agent System",
+        "goal": "Coordinate specialized agents on top of stable trading, risk, and observability foundations.",
+        "gate": "Agent autonomy must remain subordinate to supervisor and risk decisions.",
+        "tasks": [
+          {
+            "id": "P6-T28",
+            "title": "Create multi-agent architecture",
+            "owner": "supervisor-agent",
+            "deliverables": ["strategy agent", "risk agent", "execution agent interfaces"],
+            "acceptance_criteria": [
+              "each agent has explicit scope and bounded authority",
+              "inter-agent messages are typed or schema-defined"
+            ],
+            "depends_on": ["P4-T19", "P5-T24"]
+          },
+          {
+            "id": "P6-T29",
+            "title": "Build task queue system for agents",
+            "owner": "supervisor-agent",
+            "deliverables": ["async job queue", "retry semantics", "dead-letter handling"],
+            "acceptance_criteria": [
+              "agent jobs can be replayed safely",
+              "failed jobs are inspectable"
+            ],
+            "depends_on": ["P6-T28", "P1-T4"]
+          },
+          {
+            "id": "P6-T30",
+            "title": "Implement supervisor agent",
+            "owner": "supervisor-agent",
+            "deliverables": ["agent evaluator", "override logic", "decision audit trail"],
+            "acceptance_criteria": [
+              "supervisor can block subordinate decisions",
+              "override actions are logged with rationale"
+            ],
+            "depends_on": ["P6-T28", "P6-T29", "P4-T20"]
+          }
+        ]
+      }
+    ],
+    "execution_order": [
+      "phase-1-core-engine",
+      "phase-4-money-control",
+      "phase-2-strategy-intelligence",
+      "phase-3-ai-learning-layer",
+      "phase-5-dashboard-control",
+      "phase-6-agent-system"
+    ],
+    "release_tracks": {
+      "paper_trading": ["phase-1-core-engine", "phase-2-strategy-intelligence", "phase-4-money-control"],
+      "live_trading_minimum": ["phase-1-core-engine", "phase-4-money-control", "phase-2-strategy-intelligence"],
+      "full_platform": [
+        "phase-1-core-engine",
+        "phase-4-money-control",
+        "phase-2-strategy-intelligence",
+        "phase-3-ai-learning-layer",
+        "phase-5-dashboard-control",
+        "phase-6-agent-system"
+      ]
+    }
+  }
+}

--- a/pipeline/pipeline-state.json
+++ b/pipeline/pipeline-state.json
@@ -1,0 +1,3 @@
+{
+  "completed_tasks": []
+}

--- a/src/codex_pipeline/__init__.py
+++ b/src/codex_pipeline/__init__.py
@@ -1,0 +1,6 @@
+"""Codex task pipeline package."""
+
+from .loader import load_pipeline, load_state, save_state
+from .planner import PipelinePlanner
+
+__all__ = ["PipelinePlanner", "load_pipeline", "load_state", "save_state"]

--- a/src/codex_pipeline/cli.py
+++ b/src/codex_pipeline/cli.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .loader import load_pipeline, load_state, save_state
+from .planner import PipelinePlanner, PipelineValidationError
+
+
+DEFAULT_PIPELINE_PATH = Path("pipeline/codex-task-pipeline.json")
+DEFAULT_STATE_PATH = Path("pipeline/pipeline-state.json")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Codex task pipeline utility")
+    parser.add_argument("command", choices=["validate", "summary", "next", "complete", "track"])
+    parser.add_argument("value", nargs="?", help="Task ID for complete, track name for track")
+    parser.add_argument("--pipeline", default=str(DEFAULT_PIPELINE_PATH))
+    parser.add_argument("--state", default=str(DEFAULT_STATE_PATH))
+    return parser
+
+
+def _format_ready_tasks(tasks: Iterable[object]) -> str:
+    lines = []
+    for task in tasks:
+        lines.append(f"- {task.id}: {task.title} ({task.owner})")
+    return "\n".join(lines) if lines else "- no unblocked tasks"
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    pipeline = load_pipeline(args.pipeline)
+    state = load_state(args.state)
+    planner = PipelinePlanner(pipeline, state)
+
+    try:
+        planner.validate()
+        if args.command == "validate":
+            print(f"valid pipeline: {pipeline.name}@{pipeline.version}")
+            return 0
+
+        if args.command == "summary":
+            print(f"Pipeline: {pipeline.name} ({pipeline.version})")
+            print(f"Objective: {pipeline.objective}")
+            for progress in planner.phase_progress():
+                print(
+                    f"- {progress.phase_id}: {progress.phase_name} "
+                    f"[{progress.completed}/{progress.total} complete, {progress.percent}%]"
+                )
+            return 0
+
+        if args.command == "next":
+            print(_format_ready_tasks(planner.ready_tasks()))
+            return 0
+
+        if args.command == "complete":
+            if not args.value:
+                parser.error("complete requires a task ID")
+            task = planner.complete_task(args.value)
+            save_state(args.state, state)
+            print(f"completed {task.id}: {task.title}")
+            return 0
+
+        if args.command == "track":
+            if not args.value:
+                parser.error("track requires a release track name")
+            print(json.dumps(planner.release_track_status(args.value), indent=2))
+            return 0
+    except PipelineValidationError as exc:
+        print(f"error: {exc}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_pipeline/loader.py
+++ b/src/codex_pipeline/loader.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .models import Phase, Pipeline, PipelineState, Task
+
+
+
+def _build_task(payload: Dict[str, Any]) -> Task:
+    return Task(
+        id=payload["id"],
+        title=payload["title"],
+        owner=payload["owner"],
+        deliverables=list(payload.get("deliverables", [])),
+        acceptance_criteria=list(payload.get("acceptance_criteria", [])),
+        depends_on=list(payload.get("depends_on", [])),
+    )
+
+
+def _build_phase(payload: Dict[str, Any]) -> Phase:
+    return Phase(
+        id=payload["id"],
+        name=payload["name"],
+        goal=payload["goal"],
+        gate=payload["gate"],
+        tasks=[_build_task(task) for task in payload.get("tasks", [])],
+    )
+
+
+def load_pipeline(path: str | Path) -> Pipeline:
+    pipeline_path = Path(path)
+    data = json.loads(pipeline_path.read_text())
+    payload = data["pipeline"]
+    return Pipeline(
+        name=payload["name"],
+        version=payload["version"],
+        objective=payload["objective"],
+        default_mode=payload["default_mode"],
+        global_rules=dict(payload.get("global_rules", {})),
+        agents=list(payload.get("agents", [])),
+        phases=[_build_phase(phase) for phase in payload.get("phases", [])],
+        execution_order=list(payload.get("execution_order", [])),
+        release_tracks=dict(payload.get("release_tracks", {})),
+        automation=dict(payload.get("automation", {})),
+    )
+
+
+def load_state(path: str | Path) -> PipelineState:
+    state_path = Path(path)
+    if not state_path.exists():
+        return PipelineState()
+    data = json.loads(state_path.read_text())
+    return PipelineState(completed_tasks=list(data.get("completed_tasks", [])))
+
+
+def save_state(path: str | Path, state: PipelineState) -> None:
+    state_path = Path(path)
+    state_path.write_text(
+        json.dumps({"completed_tasks": state.completed_tasks}, indent=2) + "\n"
+    )

--- a/src/codex_pipeline/models.py
+++ b/src/codex_pipeline/models.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class Task:
+    id: str
+    title: str
+    owner: str
+    deliverables: List[str]
+    acceptance_criteria: List[str]
+    depends_on: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Phase:
+    id: str
+    name: str
+    goal: str
+    gate: str
+    tasks: List[Task]
+
+
+@dataclass(frozen=True)
+class Pipeline:
+    name: str
+    version: str
+    objective: str
+    default_mode: str
+    global_rules: Dict[str, object]
+    agents: List[Dict[str, object]]
+    phases: List[Phase]
+    execution_order: List[str]
+    release_tracks: Dict[str, List[str]]
+    automation: Dict[str, object]
+
+    @property
+    def tasks_by_id(self) -> Dict[str, Task]:
+        return {
+            task.id: task
+            for phase in self.phases
+            for task in phase.tasks
+        }
+
+
+@dataclass
+class PipelineState:
+    completed_tasks: List[str] = field(default_factory=list)
+
+    def is_complete(self, task_id: str) -> bool:
+        return task_id in self.completed_tasks
+
+    def mark_complete(self, task_id: str) -> None:
+        if task_id not in self.completed_tasks:
+            self.completed_tasks.append(task_id)
+            self.completed_tasks.sort()

--- a/src/codex_pipeline/planner.py
+++ b/src/codex_pipeline/planner.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Set
+
+from .models import Phase, Pipeline, PipelineState, Task
+
+
+@dataclass(frozen=True)
+class PhaseProgress:
+    phase_id: str
+    phase_name: str
+    completed: int
+    total: int
+
+    @property
+    def percent(self) -> int:
+        if self.total == 0:
+            return 100
+        return int((self.completed / self.total) * 100)
+
+
+class PipelineValidationError(ValueError):
+    pass
+
+
+class PipelinePlanner:
+    def __init__(self, pipeline: Pipeline, state: PipelineState | None = None) -> None:
+        self.pipeline = pipeline
+        self.state = state or PipelineState()
+
+    def validate(self) -> None:
+        tasks = self.pipeline.tasks_by_id
+        if len(tasks) != sum(len(phase.tasks) for phase in self.pipeline.phases):
+            raise PipelineValidationError("duplicate task IDs detected")
+
+        phase_ids = {phase.id for phase in self.pipeline.phases}
+        for phase_id in self.pipeline.execution_order:
+            if phase_id not in phase_ids:
+                raise PipelineValidationError(f"execution order references unknown phase: {phase_id}")
+
+        for track_name, phase_list in self.pipeline.release_tracks.items():
+            for phase_id in phase_list:
+                if phase_id not in phase_ids:
+                    raise PipelineValidationError(
+                        f"release track {track_name} references unknown phase: {phase_id}"
+                    )
+
+        for task in tasks.values():
+            for dependency in task.depends_on:
+                if dependency not in tasks:
+                    raise PipelineValidationError(
+                        f"task {task.id} depends on unknown task {dependency}"
+                    )
+
+        self._assert_acyclic(tasks.values())
+
+    def _assert_acyclic(self, tasks: Iterable[Task]) -> None:
+        graph: Dict[str, List[str]] = {task.id: list(task.depends_on) for task in tasks}
+        visiting: Set[str] = set()
+        visited: Set[str] = set()
+
+        def visit(task_id: str) -> None:
+            if task_id in visited:
+                return
+            if task_id in visiting:
+                raise PipelineValidationError(f"cycle detected at {task_id}")
+            visiting.add(task_id)
+            for dependency in graph[task_id]:
+                visit(dependency)
+            visiting.remove(task_id)
+            visited.add(task_id)
+
+        for task_id in graph:
+            visit(task_id)
+
+    def ready_tasks(self) -> List[Task]:
+        tasks = self.pipeline.tasks_by_id
+        ready = []
+        for task in tasks.values():
+            if self.state.is_complete(task.id):
+                continue
+            if all(self.state.is_complete(dep) for dep in task.depends_on):
+                ready.append(task)
+        return sorted(ready, key=lambda task: task.id)
+
+    def phase_progress(self) -> List[PhaseProgress]:
+        progress = []
+        for phase in self.pipeline.phases:
+            completed = sum(1 for task in phase.tasks if self.state.is_complete(task.id))
+            progress.append(
+                PhaseProgress(
+                    phase_id=phase.id,
+                    phase_name=phase.name,
+                    completed=completed,
+                    total=len(phase.tasks),
+                )
+            )
+        return progress
+
+    def complete_task(self, task_id: str) -> Task:
+        task = self.pipeline.tasks_by_id.get(task_id)
+        if task is None:
+            raise PipelineValidationError(f"unknown task: {task_id}")
+        missing = [dep for dep in task.depends_on if not self.state.is_complete(dep)]
+        if missing:
+            raise PipelineValidationError(
+                f"task {task_id} cannot be completed before dependencies: {', '.join(missing)}"
+            )
+        self.state.mark_complete(task_id)
+        return task
+
+    def phase_by_id(self, phase_id: str) -> Phase:
+        for phase in self.pipeline.phases:
+            if phase.id == phase_id:
+                return phase
+        raise PipelineValidationError(f"unknown phase: {phase_id}")
+
+    def release_track_status(self, track_name: str) -> Dict[str, object]:
+        phases = self.pipeline.release_tracks.get(track_name)
+        if phases is None:
+            raise PipelineValidationError(f"unknown release track: {track_name}")
+        entries = []
+        all_complete = True
+        for phase_id in phases:
+            phase = self.phase_by_id(phase_id)
+            total = len(phase.tasks)
+            completed = sum(1 for task in phase.tasks if self.state.is_complete(task.id))
+            is_complete = completed == total
+            if not is_complete:
+                all_complete = False
+            entries.append(
+                {
+                    "phase_id": phase_id,
+                    "phase_name": phase.name,
+                    "completed": completed,
+                    "total": total,
+                    "is_complete": is_complete,
+                }
+            )
+        return {"track": track_name, "is_complete": all_complete, "phases": entries}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,58 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from codex_pipeline.loader import load_pipeline, load_state, save_state
+from codex_pipeline.models import PipelineState
+from codex_pipeline.planner import PipelinePlanner, PipelineValidationError
+
+
+PIPELINE_PATH = Path("pipeline/codex-task-pipeline.json")
+
+
+class PipelinePlannerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.pipeline = load_pipeline(PIPELINE_PATH)
+        self.state = PipelineState()
+        self.planner = PipelinePlanner(self.pipeline, self.state)
+
+    def test_pipeline_validates(self) -> None:
+        self.planner.validate()
+
+    def test_ready_tasks_starts_with_first_core_task(self) -> None:
+        ready = [task.id for task in self.planner.ready_tasks()]
+        self.assertEqual(["P1-T1"], ready)
+
+    def test_dependency_rules_block_premature_completion(self) -> None:
+        with self.assertRaises(PipelineValidationError):
+            self.planner.complete_task("P1-T3")
+
+    def test_completion_unlocks_next_task(self) -> None:
+        self.planner.complete_task("P1-T1")
+        ready = [task.id for task in self.planner.ready_tasks()]
+        self.assertIn("P1-T2", ready)
+        self.assertNotIn("P1-T3", ready)
+
+    def test_state_round_trip(self) -> None:
+        self.state.mark_complete("P1-T1")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            save_state(state_path, self.state)
+            reloaded = load_state(state_path)
+        self.assertEqual(["P1-T1"], reloaded.completed_tasks)
+
+    def test_release_track_status(self) -> None:
+        status = self.planner.release_track_status("paper_trading")
+        self.assertFalse(status["is_complete"])
+        self.assertEqual(3, len(status["phases"]))
+
+
+class PipelineShapeTests(unittest.TestCase):
+    def test_pipeline_contains_five_phases(self) -> None:
+        payload = json.loads(PIPELINE_PATH.read_text())["pipeline"]
+        self.assertEqual(5, len(payload["phases"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Convert the multi-phase trading-bot roadmap into a machine-readable task graph so work can be executed, gated, and automated by Codex rather than left as an unstructured checklist.
- Make sequencing and safety explicit by surfacing agent ownership, dependencies, acceptance criteria, and release tracks so foundational risk and observability work is prioritized before AI/strategy rollout.

### Description

- Add `pipeline/codex-task-pipeline.json` which encodes phases, tasks (IDs, owners, deliverables, acceptance criteria, dependencies), agents, `execution_order`, and `release_tracks` for staged delivery.
- Add `docs/codex-task-pipeline.md` which documents how to use the pipeline with Codex, the recommended execution order, prompt template for tasks, and the rationale for phase gates.
- Update `README.md` to point at the pipeline and docs and list recommended first tasks to start implementation.

### Testing

- Run a small validation `python` snippet that loads `pipeline/codex-task-pipeline.json` and asserts the first task ID equals `P1-T1`, which completed successfully and printed `validated pipeline/codex-task-pipeline.json`.
- Verified repository state with `git status --short` and `git log -1 --oneline` and confirmed the changes were committed (commit short hash `6c995d6`).
- No additional automated unit tests exist for this documentation/pipeline change; the JSON load/assert validation passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed2d32728832bbb49d3e6cd8a8a9a)