### PR TITLE
Add Yo CLI generator with deterministic blueprints, tests, benchmarks and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,106 @@
 # yo
+
+Yo is a zero-dependency command-line generator that turns a theme into a powerful, unique blueprint. It is designed for rapid planning, deterministic reproducibility, and realistic MVP workflow iteration.
+
+## Usage
+
+Generate one blueprint in Markdown:
+
+```bash
+python yo.py "strategic clarity"
+```
+
+Generate JSON output:
+
+```bash
+python yo.py "strategic clarity" --json
+```
+
+Use a seed for deterministic variation:
+
+```bash
+python yo.py "strategic clarity" --seed "alpha"
+```
+
+Generate multiple alternatives for review:
+
+```bash
+python yo.py "strategic clarity" --count 3
+```
+
+Tailor protocol language to your workflow (`general`, `founder`, `product`, `creator`):
+
+```bash
+python yo.py "strategic clarity" --profile founder
+```
+
+Write output to a file (directories auto-create):
+
+```bash
+python yo.py "strategic clarity" --count 3 --output plans/blueprints.md
+```
+
+## Output Sections
+
+Each blueprint includes:
+
+- Title and tagline
+- Power Core
+- Unique Edge
+- Protocol
+- Signature Metrics
+- Leverage Stack
+- Threats to Disarm
+- Invocation
+
+## Testing
+
+```bash
+python -m unittest discover -s tests
+```
+
+## Benchmarking
+
+Hot benchmarks (in-process build/render):
+
+```bash
+python benchmarks/benchmark_yo.py --mode hot --runs 200
+```
+
+Cold-space benchmark (fresh CLI process with `__pycache__` cleared before each run):
+
+```bash
+python benchmarks/benchmark_yo.py --mode cold --runs 200
+```
+
+All benchmarks together:
+
+```bash
+python benchmarks/benchmark_yo.py --mode all --runs 200
+```
+
+Machine-readable benchmark report:
+
+```bash
+python benchmarks/benchmark_yo.py --mode all --runs 200 --json
+```
+
+Example output (machine-dependent):
+
+```text
+[build_one] runs=200
+[build_one] mean_ms=0.036
+[build_one] p95_ms=0.051
+[build_three] runs=200
+[build_three] mean_ms=0.105
+[build_three] p95_ms=0.130
+[render_markdown] runs=200
+[render_markdown] mean_ms=0.024
+[render_markdown] p95_ms=0.033
+[render_json] runs=200
+[render_json] mean_ms=0.073
+[render_json] p95_ms=0.111
+[cold_cli_json_count3] runs=200
+[cold_cli_json_count3] mean_ms=79.500
+[cold_cli_json_count3] p95_ms=91.300
+```

--- a/benchmarks/benchmark_yo.py
+++ b/benchmarks/benchmark_yo.py
@@ -1,0 +1,124 @@
+import argparse
+import json
+import pathlib
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import yo
+
+
+def benchmark(label: str, fn, runs: int) -> dict[str, float]:
+    timings = []
+    for _ in range(runs):
+        start = time.perf_counter()
+        fn()
+        timings.append(time.perf_counter() - start)
+    return {
+        "runs": runs,
+        "mean_ms": statistics.mean(timings) * 1000,
+        "p95_ms": statistics.quantiles(timings, n=20)[-1] * 1000,
+    }
+
+
+def run_hot_benchmarks(runs: int) -> dict[str, dict[str, float]]:
+    blueprint = yo.build_blueprint("focus", seed="alpha")
+    return {
+        "build_one": benchmark("build_one", lambda: yo.build_blueprint("focus", seed="alpha"), runs),
+        "build_three": benchmark(
+            "build_three",
+            lambda: yo.build_blueprints("focus", seed="alpha", count=3, profile="general"),
+            runs,
+        ),
+        "render_markdown": benchmark("render_markdown", lambda: yo.render_markdown(blueprint), runs),
+        "render_json": benchmark("render_json", lambda: yo.render_json(blueprint), runs),
+    }
+
+
+def clear_pycache() -> None:
+    for path in ROOT.rglob("__pycache__"):
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def run_cold_process(command: list[str], cwd: pathlib.Path) -> float:
+    start = time.perf_counter()
+    subprocess.run(command, cwd=cwd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return time.perf_counter() - start
+
+
+def run_cold_benchmarks(runs: int) -> dict[str, dict[str, float]]:
+    timings = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = pathlib.Path(tmpdir) / "out.json"
+        for _ in range(runs):
+            clear_pycache()
+            duration = run_cold_process(
+                [
+                    "python",
+                    "yo.py",
+                    "focus",
+                    "--json",
+                    "--count",
+                    "3",
+                    "--profile",
+                    "product",
+                    "--output",
+                    str(out_path),
+                ],
+                cwd=ROOT,
+            )
+            timings.append(duration)
+    return {
+        "cold_cli_json_count3": {
+            "runs": runs,
+            "mean_ms": statistics.mean(timings) * 1000,
+            "p95_ms": statistics.quantiles(timings, n=20)[-1] * 1000,
+        }
+    }
+
+
+def print_results(results: dict[str, dict[str, float]]) -> None:
+    for label, values in results.items():
+        print(f"[{label}] runs={int(values['runs'])}")
+        print(f"[{label}] mean_ms={values['mean_ms']:.3f}")
+        print(f"[{label}] p95_ms={values['p95_ms']:.3f}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run hot/cold benchmarks for yo")
+    parser.add_argument("--runs", type=int, default=200, help="Number of runs per benchmark group")
+    parser.add_argument(
+        "--mode",
+        choices=["hot", "cold", "all"],
+        default="all",
+        help="Benchmark mode",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.runs < 20:
+        raise SystemExit("runs must be at least 20 for stable p95 output")
+
+    output: dict[str, dict[str, float]] = {}
+    if args.mode in {"hot", "all"}:
+        output.update(run_hot_benchmarks(args.runs))
+    if args.mode in {"cold", "all"}:
+        output.update(run_cold_benchmarks(args.runs))
+
+    if args.json:
+        print(json.dumps(output, indent=2))
+    else:
+        print_results(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_yo.py
+++ b/tests/test_yo.py
@@ -1,0 +1,125 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yo
+
+
+class TestYoBlueprint(unittest.TestCase):
+    def test_deterministic_seed(self):
+        first = yo.build_blueprint("focus", seed="alpha")
+        second = yo.build_blueprint("focus", seed="alpha")
+        self.assertEqual(first, second)
+
+    def test_json_render_includes_keys(self):
+        blueprint = yo.build_blueprint("focus", seed="alpha")
+        payload = json.loads(yo.render_json(blueprint))
+        for key in [
+            "title",
+            "tagline",
+            "power_core",
+            "unique_edge",
+            "protocol",
+            "metrics",
+            "leverage",
+            "threats",
+            "invocation",
+        ]:
+            self.assertIn(key, payload)
+
+    def test_sanitized_theme(self):
+        blueprint = yo.build_blueprint("*** strategic clarity!!!", seed="x")
+        self.assertIn("Strategic Clarity", blueprint.title)
+
+    def test_multiple_variations_count(self):
+        blueprints = yo.build_blueprints("focus", seed="alpha", count=3)
+        self.assertEqual(len(blueprints), 3)
+        self.assertEqual(len({bp.title for bp in blueprints}), 3)
+
+    def test_profile_changes_protocol_language(self):
+        blueprints = yo.build_blueprints("focus", seed="alpha", count=1, profile="founder")
+        protocol = blueprints[0].protocol
+        self.assertIn("strategic bet", protocol[0])
+        self.assertIn("customer-facing artifact", protocol[3])
+
+    def test_short_invalid_theme_raises(self):
+        with self.assertRaises(yo.YoError):
+            yo.build_blueprint("!!", seed="alpha")
+
+    def test_cli_output_file_write(self):
+        root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "nested" / "blueprint.md"
+            proc = subprocess.run(
+                [
+                    "python",
+                    str(root / "yo.py"),
+                    "strategic clarity",
+                    "--output",
+                    str(out),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0)
+            self.assertTrue(out.exists())
+            self.assertIn("Engine", out.read_text(encoding="utf-8"))
+
+    def test_cli_json_count(self):
+        root = Path(__file__).resolve().parents[1]
+        proc = subprocess.run(
+            [
+                "python",
+                str(root / "yo.py"),
+                "focus",
+                "--count",
+                "2",
+                "--json",
+                "--seed",
+                "alpha",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(len(payload), 2)
+
+    def test_invalid_count_fails(self):
+        root = Path(__file__).resolve().parents[1]
+        proc = subprocess.run(
+            ["python", str(root / "yo.py"), "focus", "--count", "0"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("count must be between 1 and 20", proc.stderr)
+
+    def test_cli_profile_flag(self):
+        root = Path(__file__).resolve().parents[1]
+        proc = subprocess.run(
+            [
+                "python",
+                str(root / "yo.py"),
+                "focus",
+                "--profile",
+                "creator",
+                "--seed",
+                "alpha",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("audience outcome", proc.stdout)
+        self.assertIn("publishable artifact", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yo.py
+++ b/yo.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Yo: generate powerful, unique blueprints from a theme."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import re
+import sys
+import textwrap
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+SYLLABLES = [
+    "ka",
+    "zu",
+    "mi",
+    "ra",
+    "to",
+    "shi",
+    "va",
+    "no",
+    "lu",
+    "xe",
+    "tri",
+    "zen",
+    "or",
+    "py",
+    "el",
+    "un",
+]
+
+VERBS = [
+    "amplify",
+    "forge",
+    "liberate",
+    "reframe",
+    "synthesize",
+    "accelerate",
+    "anchor",
+    "transmute",
+    "orchestrate",
+    "architect",
+    "ignite",
+]
+
+NOUNS = [
+    "signal",
+    "momentum",
+    "clarity",
+    "energy",
+    "trust",
+    "curiosity",
+    "alignment",
+    "resilience",
+    "craft",
+    "velocity",
+    "gravity",
+]
+
+FORCES = [
+    "time",
+    "attention",
+    "complexity",
+    "ambiguity",
+    "entropy",
+    "surprise",
+    "pressure",
+    "distance",
+    "noise",
+]
+
+PRINCIPLES = [
+    "Make the invisible measurable.",
+    "Design for compounding wins.",
+    "Favor rituals over heroics.",
+    "Treat feedback as fuel.",
+    "Move slow only on irreversible bets.",
+    "Make constraints your signature.",
+]
+
+RITUALS = [
+    "Dawn scan: capture the strongest signal in 60 seconds.",
+    "Two-horizon planning: now vs. next.",
+    "90-minute creation sprint, no switching.",
+    "Weekly friction review: name the drag, remove it.",
+    "End-of-day resonance check: what echoed?",
+]
+
+METRICS = [
+    "Signal-to-noise ratio",
+    "Momentum half-life",
+    "Decision latency",
+    "Insight yield",
+    "Trust delta",
+]
+
+LEVERAGE = [
+    "automation",
+    "community",
+    "code",
+    "capital",
+    "craft",
+    "partnerships",
+    "distribution",
+    "reputation",
+]
+
+THREATS = [
+    "drift",
+    "fragmentation",
+    "over-optimization",
+    "unclear ownership",
+    "premature scaling",
+    "stale narratives",
+    "context switching",
+]
+
+THEME_RE = re.compile(r"[^a-z0-9\s\-]", flags=re.IGNORECASE)
+
+PROFILE_HINTS = {
+    "general": {
+        "target": "decision",
+        "cadence": "weekly",
+        "artifact": "proof artifact",
+    },
+    "founder": {
+        "target": "strategic bet",
+        "cadence": "daily",
+        "artifact": "customer-facing artifact",
+    },
+    "product": {
+        "target": "product outcome",
+        "cadence": "weekly",
+        "artifact": "validated learning artifact",
+    },
+    "creator": {
+        "target": "audience outcome",
+        "cadence": "daily",
+        "artifact": "publishable artifact",
+    },
+}
+
+
+@dataclass(eq=True)
+class Blueprint:
+    title: str
+    tagline: str
+    power_core: list[str]
+    unique_edge: list[str]
+    protocol: list[str]
+    metrics: list[str]
+    leverage: list[str]
+    threats: list[str]
+    invocation: str
+
+
+class YoError(Exception):
+    """Raised for user-facing command errors."""
+
+
+def _seed_from(theme: str, seed: str | None) -> int:
+    combo = f"{theme}::{seed or ''}"
+    digest = hashlib.sha256(combo.encode("utf-8")).hexdigest()
+    return int(digest, 16) % (2**32)
+
+
+def _syllable_name(rng: random.Random, count: int = 3) -> str:
+    return "".join(rng.choice(SYLLABLES) for _ in range(count)).title()
+
+
+def _pick(rng: random.Random, items: list[str], count: int) -> list[str]:
+    return rng.sample(items, count)
+
+
+def _sanitize_theme(theme: str) -> str:
+    cleaned = THEME_RE.sub("", theme).strip()
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    if len(cleaned) < 3:
+        raise YoError("theme must be at least 3 valid characters")
+    return cleaned
+
+
+def build_blueprint(theme: str, seed: str | None) -> Blueprint:
+    theme = _sanitize_theme(theme)
+    rng = random.Random(_seed_from(theme, seed))
+    name = _syllable_name(rng)
+    verb = rng.choice(VERBS)
+    noun = rng.choice(NOUNS)
+    force = rng.choice(FORCES)
+    tagline = f"{verb.title()} {noun} by mastering {force}."
+
+    power_core = [
+        f"Harness {rng.choice(NOUNS)} to sharpen the {theme} signal.",
+        f"Turn {rng.choice(FORCES)} into a repeatable advantage.",
+        f"Convert {rng.choice(NOUNS)} into collective leverage.",
+    ]
+
+    unique_edge = [rng.choice(PRINCIPLES) for _ in range(3)]
+
+    protocol = [
+        f"Name the prime target: the most consequential {theme} decision this week.",
+        f"Build a minimum ritual: {rng.choice(RITUALS)}",
+        f"Install a guardrail against {rng.choice(FORCES)}.",
+        "Ship one proof artifact in 72 hours.",
+    ]
+
+    metrics = _pick(rng, METRICS, 3)
+    leverage = _pick(rng, LEVERAGE, 3)
+    threats = _pick(rng, THREATS, 2)
+    invocation = f"We are the {name} order. We {verb} {noun} with intent."
+
+    return Blueprint(
+        title=f"{name} Engine: {theme.title()}",
+        tagline=tagline,
+        power_core=power_core,
+        unique_edge=unique_edge,
+        protocol=protocol,
+        metrics=metrics,
+        leverage=leverage,
+        threats=threats,
+        invocation=invocation,
+    )
+
+
+def apply_profile(blueprint: Blueprint, theme: str, profile: str) -> Blueprint:
+    hints = PROFILE_HINTS[profile]
+    protocol = blueprint.protocol.copy()
+    protocol[0] = (
+        f"Name the prime target: the most consequential {theme} {hints['target']} "
+        f"this {hints['cadence']}."
+    )
+    protocol[3] = f"Ship one {hints['artifact']} in 72 hours."
+    return Blueprint(
+        title=blueprint.title,
+        tagline=blueprint.tagline,
+        power_core=blueprint.power_core,
+        unique_edge=blueprint.unique_edge,
+        protocol=protocol,
+        metrics=blueprint.metrics,
+        leverage=blueprint.leverage,
+        threats=blueprint.threats,
+        invocation=blueprint.invocation,
+    )
+
+
+def build_blueprints(
+    theme: str,
+    seed: str | None,
+    count: int,
+    profile: str = "general",
+) -> list[Blueprint]:
+    if count < 1 or count > 20:
+        raise YoError("count must be between 1 and 20")
+    if profile not in PROFILE_HINTS:
+        allowed = ", ".join(PROFILE_HINTS)
+        raise YoError(f"profile must be one of: {allowed}")
+    blueprints = [build_blueprint(theme, f"{seed or 'seed'}:{idx}") for idx in range(count)]
+    return [apply_profile(blueprint, theme, profile) for blueprint in blueprints]
+
+
+def render_markdown(blueprint: Blueprint) -> str:
+    lines = [
+        f"# {blueprint.title}",
+        "",
+        f"**{blueprint.tagline}**",
+        "",
+        "## Power Core",
+        *[f"- {item}" for item in blueprint.power_core],
+        "",
+        "## Unique Edge",
+        *[f"- {item}" for item in blueprint.unique_edge],
+        "",
+        "## Protocol",
+        *[f"{idx + 1}. {item}" for idx, item in enumerate(blueprint.protocol)],
+        "",
+        "## Signature Metrics",
+        *[f"- {item}" for item in blueprint.metrics],
+        "",
+        "## Leverage Stack",
+        *[f"- {item.title()}" for item in blueprint.leverage],
+        "",
+        "## Threats to Disarm",
+        *[f"- {item}" for item in blueprint.threats],
+        "",
+        "## Invocation",
+        textwrap.fill(blueprint.invocation, width=72),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def render_markdown_many(blueprints: list[Blueprint]) -> str:
+    return "\n---\n\n".join(render_markdown(blueprint).strip() for blueprint in blueprints)
+
+
+def render_json(data: Blueprint | list[Blueprint]) -> str:
+    if isinstance(data, list):
+        payload = [asdict(item) for item in data]
+    else:
+        payload = asdict(data)
+    return json.dumps(payload, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a powerful, unique blueprint from a theme.",
+    )
+    parser.add_argument("theme", help="Theme or mission for the blueprint")
+    parser.add_argument("--seed", help="Optional seed for deterministic output")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON instead of Markdown",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=1,
+        help="Generate multiple blueprint variations (1-20)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Write output to a file instead of stdout",
+    )
+    parser.add_argument(
+        "--profile",
+        default="general",
+        choices=sorted(PROFILE_HINTS.keys()),
+        help="Tailor protocol language for a target workflow",
+    )
+    return parser.parse_args()
+
+
+def _write_output(output: str, output_path: str) -> None:
+    try:
+        path = Path(output_path)
+        if path.parent and not path.parent.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(output + "\n", encoding="utf-8")
+    except OSError as exc:
+        raise YoError(f"failed to write output: {exc}") from exc
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        payload: Blueprint | list[Blueprint]
+        payload = build_blueprints(args.theme, args.seed, args.count, profile=args.profile)
+        if args.count == 1:
+            payload = payload[0]
+
+        if args.json:
+            output = render_json(payload)
+        elif isinstance(payload, list):
+            output = render_markdown_many(payload)
+        else:
+            output = render_markdown(payload)
+
+        if args.output:
+            _write_output(output, args.output)
+        else:
+            print(output)
+    except YoError as exc:
+        print(f"yo: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a zero-dependency CLI tool (`yo.py`) that generates deterministic, reproducible blueprints from a theme for rapid planning and MVP iteration.
- Add profile-aware protocol language and both Markdown and JSON renderers to support different workflows and output targets.
- Add benchmarking and tests to measure performance and ensure deterministic behavior and CLI correctness.

### Description

- Introduce `yo.py`, a complete CLI app that defines a `Blueprint` dataclass, deterministic seeding (`_seed_from`), blueprint builders (`build_blueprint`, `build_blueprints`), profile application (`apply_profile`), and renderers (`render_markdown`, `render_json`).
- Implement argument parsing and file output handling in `main()` with user-facing errors via `YoError` and safe file writes in `_write_output`.
- Add `tests/test_yo.py` with unit and CLI integration tests validating determinism, JSON/Markdown output, profile behavior, input validation, and file writing.
- Add `benchmarks/benchmark_yo.py` to run hot (in-process) and cold (fresh CLI process) benchmarks, and update `README.md` and `.gitignore` with usage, testing, and benchmarking instructions.

### Testing

- Ran the test suite with `python -m unittest discover -s tests`, which executed the unit and CLI integration tests and all tests passed.
- The test run exercised deterministic seeding, JSON/Markdown rendering, profile variations, input validation, and CLI file-writing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_698933b101cc832bb39771fafcba7b98)